### PR TITLE
Fix RubyGems URLs for homepage and source_code

### DIFF
--- a/ipa_test_kit.gemspec
+++ b/ipa_test_kit.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['inferno@groups.mitre.org']
   spec.summary       = 'IPA Inferno tests'
   spec.description   = 'IPA Inferno tests'
-  spec.homepage      = 'https://github.com/inferno_framework/ipa-test-kit'
+  spec.homepage      = 'https://github.com/inferno-framework/ipa-test-kit'
   spec.license       = 'Apache-2.0'
   spec.add_runtime_dependency 'inferno_core', '>= 0.4.2'
   spec.add_runtime_dependency 'smart_app_launch_test_kit', '~> 0.3'
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.11'
   spec.required_ruby_version = Gem::Requirement.new('>= 3.1.2')
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/inferno_framework/ipa-test-kit'
+  spec.metadata['source_code_uri'] = 'https://github.com/inferno-framework/ipa-test-kit'
   spec.files = [
     Dir['lib/**/*.rb'],
     Dir['lib/**/*.json'],


### PR DESCRIPTION
# Summary

Fixing typo in RubyGems homepage and source_code links.

# Testing Guidance

`gem build ipa-test-kit.gemspec`


Someone needs to push the gem to the gemserver for fixes to take effect.