### PR TITLE
 FI-2429: migrate to HL7 validator wrapper 

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,2 @@
-VALIDATOR_URL=http://localhost/validatorapi
-IPA_V100_VALIDATOR_URL=http://localhost/validatorapi
+IPA_V100_FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
 REDIS_URL=redis://localhost:6379/0

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-IPA_V100_FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
+FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
 REDIS_URL=redis://localhost:6379/0

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,3 @@
-REDIS_URL=redis://redis:6379/0
+INFERNO_HOST=http://localhost
 FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500
+REDIS_URL=redis://redis:6379/0

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,2 @@
 REDIS_URL=redis://redis:6379/0
-VALIDATOR_URL=http://validator_service:4567
+IPA_V100_FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,2 @@
 REDIS_URL=redis://redis:6379/0
-IPA_V100_FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500
+FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500

--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,2 @@
-VALIDATOR_URL=https://example.com/validatorapi
+FHIR_RESOURCE_VALIDATOR_URL=https://example.com/validatorapi
 ASYNC_JOBS=false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    inferno_core (0.4.33)
+    inferno_core (0.4.34)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
@@ -189,13 +189,14 @@ GEM
       base64
     kramdown (2.4.0)
       rexml
-    method_source (1.0.0)
+    method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0305)
     minitest (5.22.3)
     multi_json (1.15.0)
-    multi_xml (0.6.0)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     multipart-post (2.4.0)
     mustermann (1.1.2)
       ruby2_keywords (~> 0.0.1)
@@ -204,11 +205,11 @@ GEM
       mustermann (= 1.1.2)
     netrc (0.11.0)
     nio4r (2.7.1)
-    nokogiri (1.16.3-arm64-darwin)
+    nokogiri (1.16.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.3-x86_64-darwin)
+    nokogiri (1.16.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.3-x86_64-linux)
+    nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
     oauth2 (1.4.11)
       faraday (>= 0.17.3, < 3.0)
@@ -304,6 +305,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-20
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@ Implementation Guide](https://build.fhir.org/ig/HL7/fhir-ipa/).  This test kit
 is designed and maintained by the Inferno team to support the development of the
 IPA IG and improve the core Inferno Framework.
 
-This test kit includes a web interface to run a configured local [HL7® FHIR®
-validator](https://confluence.hl7.org/display/FHIR/Using+the+FHIR+Validator)
-service to validate instances of FHIR resources to the IPA profiles, as well as
-a preliminary test suite based on the [Inferno US
+This test kit includes a preliminary test suite based on the [Inferno US
 Core](https://github.com/inferno-framework/us-core-test-kit) test suite.
 
 The [Office of the National Coordinator for Health IT
@@ -24,8 +21,7 @@ be accessed at https://inferno.healthit.gov/suites/ipa_v100
   database.
 - Run `run.sh` to build and run the Inferno environment
 - Navigate to `http://localhost` to access the Inferno IPA Test Suite
-- Navigate to `http://localhost/validator` to access a FHIR resource validator,
-  configured to validate against the IPA FHIR profiles
+
 
 
 ## Maintaining this Test Kit
@@ -39,8 +35,8 @@ terminology service to validate terminology by default.
 To update this test kit to a new version of the IG:
 
 1. Add the .tgz file in `./lib/ipa_test_kit/igs` with the new version
-of the IG package.  This will automatically be uploaded to the HL7
-FHIR Validator to validate resource instance when the Inferno is started.
+of the IG package.  This IG will be used by the HL7 FHIR Validator to 
+validate resource instances when Inferno is started.
 2. Run the generator to generate a new version-specific copy of the IPA suite.
    After installing Ruby, run the following:
 

--- a/config/nginx.background.conf
+++ b/config/nginx.background.conf
@@ -53,7 +53,38 @@ http {
     # the server will close connections after this time
     keepalive_timeout 600;
 
-    location /validator {
+#    location /validator {
+#      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#      proxy_set_header Host $http_host;
+#      proxy_set_header X-Forwarded-Proto $scheme;
+#      proxy_set_header X-Forwarded-Port $server_port;
+#      proxy_redirect off;
+#      proxy_set_header Connection '';
+#      proxy_http_version 1.1;
+#      chunked_transfer_encoding off;
+#      proxy_buffering off;
+#      proxy_cache off;
+#
+#      proxy_pass http://fhir_validator_app;
+#    }
+
+#    location /validatorapi/ {
+#      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#      proxy_set_header Host $http_host;
+#      proxy_set_header X-Forwarded-Proto $scheme;
+#      proxy_set_header X-Forwarded-Port $server_port;
+#      proxy_redirect off;
+#      proxy_set_header Connection '';
+#      proxy_http_version 1.1;
+#      chunked_transfer_encoding off;
+#      proxy_buffering off;
+#      proxy_cache off;
+#
+#      proxy_pass http://validator_service:4567/;
+#    }
+#  }
+
+    location /hl7validatorapi/ {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto $scheme;
@@ -64,23 +95,9 @@ http {
       chunked_transfer_encoding off;
       proxy_buffering off;
       proxy_cache off;
+      proxy_read_timeout 600s;
 
-      proxy_pass http://fhir_validator_app;
-    }
-
-    location /validatorapi/ {
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header X-Forwarded-Port $server_port;
-      proxy_redirect off;
-      proxy_set_header Connection '';
-      proxy_http_version 1.1;
-      chunked_transfer_encoding off;
-      proxy_buffering off;
-      proxy_cache off;
-
-      proxy_pass http://validator_service:4567/;
+      proxy_pass http://hl7_validator_service:3500/;
     }
   }
 }

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -68,7 +68,37 @@ http {
       proxy_pass http://inferno:4567;
     }
 
-    location /validator {
+#    location /validator {
+#      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#      proxy_set_header Host $http_host;
+#      proxy_set_header X-Forwarded-Proto $scheme;
+#      proxy_set_header X-Forwarded-Port $server_port;
+#      proxy_redirect off;
+#      proxy_set_header Connection '';
+#      proxy_http_version 1.1;
+#      chunked_transfer_encoding off;
+#      proxy_buffering off;
+#      proxy_cache off;
+#
+#      proxy_pass http://fhir_validator_app;
+#    }
+
+#    location /validatorapi/ {
+#      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#      proxy_set_header Host $http_host;
+#      proxy_set_header X-Forwarded-Proto $scheme;
+#      proxy_set_header X-Forwarded-Port $server_port;
+#      proxy_redirect off;
+#      proxy_set_header Connection '';
+#      proxy_http_version 1.1;
+#      chunked_transfer_encoding off;
+#      proxy_buffering off;
+#      proxy_cache off;
+#
+#      proxy_pass http://validator_service:4567/;
+#    }
+
+    location /hl7validatorapi/ {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto $scheme;
@@ -79,23 +109,9 @@ http {
       chunked_transfer_encoding off;
       proxy_buffering off;
       proxy_cache off;
+      proxy_read_timeout 600s;
 
-      proxy_pass http://fhir_validator_app;
-    }
-
-    location /validatorapi/ {
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header X-Forwarded-Port $server_port;
-      proxy_redirect off;
-      proxy_set_header Connection '';
-      proxy_http_version 1.1;
-      chunked_transfer_encoding off;
-      proxy_buffering off;
-      proxy_cache off;
-
-      proxy_pass http://validator_service:4567/;
+      proxy_pass http://hl7_validator_service:3500/;
     }
   }
 }

--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -1,17 +1,28 @@
 version: '3'
 services:
-  validator_service:
-    image: infernocommunity/fhir-validator-service
-    # Update this path to match your directory structure
-    volumes:
-      - ./lib/ipa_test_kit/igs:/home/igs
-  fhir_validator_app:
-    image: infernocommunity/fhir-validator-app
-    depends_on:
-      - validator_service
+  hl7_validator_service:
+    image: infernocommunity/inferno-resource-validator
     environment:
-      EXTERNAL_VALIDATOR_URL: http://localhost/validatorapi
-      VALIDATOR_BASE_PATH: /validator
+      # Defines how long validator sessions last if unused, in minutes:
+      # Negative values mean sessions never expire, 0 means sessions immediately expire
+      SESSION_CACHE_DURATION: -1
+    volumes:
+      - ./lib/ipa_test_kit/igs:/app/igs
+      # To let the service share your local FHIR package cache,
+      # uncomment the below line
+      # - ~/.fhir:/home/ktor/.fhir
+  # validator_service:
+  #   image: infernocommunity/fhir-validator-service
+  #   # Update this path to match your directory structure
+  #   volumes:
+  #     - ./lib/ipa_test_kit/igs:/home/igs
+  # fhir_validator_app:
+  #   image: infernocommunity/fhir-validator-app
+  #   depends_on:
+  #     - validator_service
+  #   environment:
+  #     EXTERNAL_VALIDATOR_URL: http://localhost/validatorapi
+  #     VALIDATOR_BASE_PATH: /validator
   nginx:
     image: nginx
     volumes:
@@ -20,7 +31,8 @@ services:
       - "80:80"
     command: [nginx, '-g', 'daemon off;']
     depends_on:
-      - fhir_validator_app
+      - hl7_validator_service
+      # - fhir_validator_app
   redis:
     image: redis
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     volumes:
       - ./data:/opt/inferno/data
     depends_on:
-      - validator_service
+      - hl7_validator_service
+      # - validator_service
   worker:
     build:
       context: ./
@@ -15,14 +16,18 @@ services:
     command: bundle exec sidekiq -r ./worker.rb
     depends_on:
       - redis
-  validator_service:
+  hl7_validator_service:
     extends:
       file: docker-compose.background.yml
-      service: validator_service
-  fhir_validator_app:
-    extends:
-      file: docker-compose.background.yml
-      service: fhir_validator_app
+      service: hl7_validator_service
+  # validator_service:
+  #   extends:
+  #     file: docker-compose.background.yml
+  #     service: validator_service
+  # fhir_validator_app:
+  #   extends:
+  #     file: docker-compose.background.yml
+  #     service: fhir_validator_app
   nginx:
     extends:
       file: docker-compose.background.yml

--- a/lib/ipa_test_kit/generated/v1.0.0/ipa_test_suite.rb
+++ b/lib/ipa_test_kit/generated/v1.0.0/ipa_test_suite.rb
@@ -46,11 +46,13 @@ module IpaTestKit
           search.
       )
       version VERSION
+      id :ipa_v100
 
       VALIDATION_MESSAGE_FILTERS = [
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
+        /\A\S+: \S+: URL value '.*' does not resolve/,
       ].freeze
 
       def self.metadata
@@ -59,8 +61,10 @@ module IpaTestKit
           end
       end
 
-      validator do
-        url ENV.fetch('IPA_V100_VALIDATOR_URL', 'http://validator_service:4567')
+      fhir_resource_validator do
+        url ENV.fetch('IPA_V100_FHIR_RESOURCE_VALIDATOR_URL', 'http://hl7_validator_service:3500')
+        igs 'hl7.fhir.uv.ipa#1.0.0'
+
         exclude_message do |message|
           VALIDATION_MESSAGE_FILTERS.any? { |filter| filter.match? message.message }
         end
@@ -69,9 +73,6 @@ module IpaTestKit
           ProvenanceValidator.validate(resource) if resource.instance_of?(FHIR::Provenance)
         end
       end
-
-      id :ipa_v100
-
 
       input :url,
         title: 'FHIR Endpoint',

--- a/lib/ipa_test_kit/generated/v1.0.0/ipa_test_suite.rb
+++ b/lib/ipa_test_kit/generated/v1.0.0/ipa_test_suite.rb
@@ -62,7 +62,6 @@ module IpaTestKit
       end
 
       fhir_resource_validator do
-        url ENV.fetch('IPA_V100_FHIR_RESOURCE_VALIDATOR_URL', 'http://hl7_validator_service:3500')
         igs 'hl7.fhir.uv.ipa#1.0.0'
 
         exclude_message do |message|

--- a/lib/ipa_test_kit/generator/suite_generator.rb
+++ b/lib/ipa_test_kit/generator/suite_generator.rb
@@ -54,7 +54,12 @@ module IpaTestKit
       end
 
       def validator_env_name
-        "IPA_#{ig_metadata.reformatted_version.upcase}_VALIDATOR_URL"
+        "IPA_#{ig_metadata.reformatted_version.upcase}_FHIR_RESOURCE_VALIDATOR_URL"
+      end
+
+      def ig_identifier
+        version = ig_metadata.ig_version[1..] # Remove leading 'v'
+        "hl7.fhir.uv.ipa##{version}"
       end
 
       def ig_link

--- a/lib/ipa_test_kit/generator/suite_generator.rb
+++ b/lib/ipa_test_kit/generator/suite_generator.rb
@@ -53,10 +53,6 @@ module IpaTestKit
         "IPA #{ig_metadata.ig_version}"
       end
 
-      def validator_env_name
-        "IPA_#{ig_metadata.reformatted_version.upcase}_FHIR_RESOURCE_VALIDATOR_URL"
-      end
-
       def ig_identifier
         version = ig_metadata.ig_version[1..] # Remove leading 'v'
         "hl7.fhir.uv.ipa##{version}"

--- a/lib/ipa_test_kit/generator/templates/suite.rb.erb
+++ b/lib/ipa_test_kit/generator/templates/suite.rb.erb
@@ -50,7 +50,6 @@ module IpaTestKit
       end
 
       fhir_resource_validator do
-        url ENV.fetch('<%= validator_env_name %>', 'http://hl7_validator_service:3500')
         igs '<%= ig_identifier %>'
 
         exclude_message do |message|

--- a/lib/ipa_test_kit/generator/templates/suite.rb.erb
+++ b/lib/ipa_test_kit/generator/templates/suite.rb.erb
@@ -34,11 +34,13 @@ module IpaTestKit
           search.
       )
       version VERSION
+      id :<%= suite_id %>
 
       VALIDATION_MESSAGE_FILTERS = [
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
+        /\A\S+: \S+: URL value '.*' does not resolve/,
       ].freeze
 
       def self.metadata
@@ -47,8 +49,10 @@ module IpaTestKit
           end
       end
 
-      validator do
-        url ENV.fetch('<%= validator_env_name %>', 'http://validator_service:4567')
+      fhir_resource_validator do
+        url ENV.fetch('<%= validator_env_name %>', 'http://hl7_validator_service:3500')
+        igs '<%= ig_identifier %>'
+
         exclude_message do |message|
           VALIDATION_MESSAGE_FILTERS.any? { |filter| filter.match? message.message }
         end
@@ -57,9 +61,6 @@ module IpaTestKit
           ProvenanceValidator.validate(resource) if resource.instance_of?(FHIR::Provenance)
         end
       end
-
-      id :<%= suite_id %>
-
 
       input :url,
         title: 'FHIR Endpoint',

--- a/lib/ipa_test_kit/igs/README.md
+++ b/lib/ipa_test_kit/igs/README.md
@@ -1,0 +1,21 @@
+# Note on this IGs folder
+
+There are three reasons why it would be necessary to put an IG package.tgz in this folder. If none of these apply, you do not need to put any files here, or can consider removing any existing files to make it clear they are unused.
+
+## 1. Generated Test Suites
+Some test kits use a "generator" to automatically generate the contents of a test suite for an IG. The IG files are required every time the test suites need to be regenerated. Examples of test kits that use this approach are the US Core Test Kit and CARIN IG for Blue Button® Test Kit.
+
+
+## 2. Non-published IG
+If your IG, or the specific version of the IG you want to test against, is not published, then the validator service needs to load the IG from file in order to be able to validate resources with it. The IG must be referenced in the `fhir_resource_validator` block in the test suite definition by filename, ie:
+
+```ruby
+      fhir_resource_validator do
+        igs 'igs/filename.tgz'
+
+        ...
+      end
+```
+
+## 3. Inferno Validator UI
+The Inferno Validator UI is configured to auto-load any IGs present in the igs folder and include them in all validations. The Inferno Validator UI is currently disabled by default, so this is only relevant if you choose to re-enable it. In general, the Inferno team is currently leaving IGs in this folder even if not otherwise necessary to make it easy to re-enable the validator UI.

--- a/lib/ipa_test_kit/reference_resolution_test.rb
+++ b/lib/ipa_test_kit/reference_resolution_test.rb
@@ -165,8 +165,8 @@ module IpaTestKit
       # Only need to know if the resource is valid.
       # Calling resource_is_valid? causes validation errors to be logged.
       validator = find_validator(:default)
-
-      outcome = FHIR::OperationOutcome.new(JSON.parse(validator.validate(resource, target_profile)))
+      validator_response = validator.validate(resource, target_profile)
+      outcome = validator.operation_outcome_from_hl7_wrapped_response(validator_response)
 
       message_hashes = outcome.issue&.map { |issue| validator.message_hash_from_issue(issue, resource) } || []
 


### PR DESCRIPTION
# Summary
Migrate to the HL7 validator wrapper:
- Get rid of suite-specific environment variables & standardize to `FHIR_RESOURCE_VALIDATOR_URL`
- As with previous test kits, left the old validator items commented out in case somebody wants to run the UI
- Bump inferno_core version
- Add the IG identifier to the generator
- Add new ignore message
- The spec tests don't seem to even run on `main` so I didn't spend much time looking at them here. From searching "validator" I saw one spot where the results had to be converted to an OO

# Testing Guidance
Results for running the tests against the reference server should match the results running on prod today, eg: https://inferno.healthit.gov/suites/ipa_v100/2ui786dWYhN#2.2