### PR TITLE
Release 0.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ipa_test_kit (0.5.1)
+    ipa_test_kit (0.6.0)
       inferno_core (>= 0.6.7)
       smart_app_launch_test_kit (~> 0.6.0)
       tls_test_kit (~> 0.3.0)
@@ -138,7 +138,7 @@ GEM
       mutex_m
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    inferno_core (0.6.7)
+    inferno_core (0.6.8)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
@@ -179,12 +179,12 @@ GEM
       base64
     kramdown (2.5.1)
       rexml (>= 3.3.9)
-    logger (1.6.6)
+    logger (1.7.0)
     method_source (1.1.0)
-    mime-types (3.6.0)
+    mime-types (3.6.2)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0304)
+    mime-types-data (3.2025.0325)
     minitest (5.25.4)
     multi_json (1.15.0)
     multi_xml (0.7.1)
@@ -198,11 +198,11 @@ GEM
     mutex_m (0.3.0)
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.18.3-arm64-darwin)
+    nokogiri (1.18.6-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.3-x86_64-darwin)
+    nokogiri (1.18.6-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.3-x86_64-linux-gnu)
+    nokogiri (1.18.6-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (1.4.11)
       faraday (>= 0.17.3, < 3.0)

--- a/lib/ipa_test_kit/version.rb
+++ b/lib/ipa_test_kit/version.rb
@@ -1,4 +1,4 @@
 module IpaTestKit
-  VERSION = '0.5.1'.freeze
-  LAST_UPDATED = '2025-03-10'.freeze
+  VERSION = '0.6.0'.freeze
+  LAST_UPDATED = '2025-03-28'.freeze
 end


### PR DESCRIPTION
# Breaking Changes

This release updates the IPA Test Kit to use AuthInfo rather than OAuthCredentials for storing auth information. As a result of this change, any test kits which rely on the IPA Test Kit will need to be updated to use AuthInfo rather than OAuthCredentials inputs.

