### PR TITLE
Remove references to private validator functions

### DIFF
--- a/lib/ipa_test_kit/reference_resolution_test.rb
+++ b/lib/ipa_test_kit/reference_resolution_test.rb
@@ -166,7 +166,7 @@ module IpaTestKit
         target_profile.include?('|') ? target_profile : "#{target_profile}|#{metadata.profile_version}"
 
       resource_is_valid?(
-        resource: resource,
+        resource:,
         profile_url: target_profile_with_version,
         add_messages_to_runnable: false
       )

--- a/lib/ipa_test_kit/reference_resolution_test.rb
+++ b/lib/ipa_test_kit/reference_resolution_test.rb
@@ -162,19 +162,16 @@ module IpaTestKit
     def resource_is_valid_with_target_profile?(resource, target_profile)
       return true if target_profile.blank?
 
-      # Only need to know if the resource is valid.
-      # Calling resource_is_valid? causes validation errors to be logged.
       validator = find_validator(:default)
-      validator_response = validator.validate(resource, target_profile)
-      outcome = validator.operation_outcome_from_hl7_wrapped_response(validator_response)
 
-      message_hashes = outcome.issue&.map { |issue| validator.message_hash_from_issue(issue, resource) } || []
-
-      message_hashes.concat(validator.additional_validation_messages(resource, target_profile))
-
-      validator.filter_messages(message_hashes)
-
-      message_hashes.none? { |message_hash| message_hash[:type] == 'error' }
+      # Use the validator's resource_is_valid? method with add_messages_to_runnable: false
+      # to validate silently without adding messages to the test output
+      validator.resource_is_valid?(
+        resource,
+        target_profile,
+        self,
+        add_messages_to_runnable: false
+      )
     end
   end
 end

--- a/lib/ipa_test_kit/reference_resolution_test.rb
+++ b/lib/ipa_test_kit/reference_resolution_test.rb
@@ -162,14 +162,12 @@ module IpaTestKit
     def resource_is_valid_with_target_profile?(resource, target_profile)
       return true if target_profile.blank?
 
-      validator = find_validator(:default)
+      target_profile_with_version =
+        target_profile.include?('|') ? target_profile : "#{target_profile}|#{metadata.profile_version}"
 
-      # Use the validator's resource_is_valid? method with add_messages_to_runnable: false
-      # to validate silently without adding messages to the test output
-      validator.resource_is_valid?(
-        resource,
-        target_profile,
-        self,
+      resource_is_valid?(
+        resource: resource,
+        profile_url: target_profile_with_version,
         add_messages_to_runnable: false
       )
     end


### PR DESCRIPTION
# Summary

Updated the reference resolution test to use the public validator service functions, rather than calling the private functions directly. Should result in no change in behavior

For proof see the following two screenshots of a validation test (2.11.10) performing identically in both production and locally (after changes):
- NOTE: Most of the tests in this kit fail on a "Unknown code in value set" error when running locally, before and after my changes. Screenshot of local run before changes added as proof

Local run before changes:
<img width="1908" height="1037" alt="image" src="https://github.com/user-attachments/assets/f6077610-ae39-429f-90a4-6a9c0d9748db" />

Local run after changes:
<img width="1898" height="1018" alt="image" src="https://github.com/user-attachments/assets/27a386cd-dfa4-4097-a2f7-ba5091397434" />

Production run:
<img width="3817" height="1813" alt="image" src="https://github.com/user-attachments/assets/4853384f-fed6-4cd4-9768-bdc4804b22a2" />

