### PR TITLE
ID-107: check types of values returned from resolve_path

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ipa_test_kit (0.7.1)
-      inferno_core (~> 1.0, >= 1.0.2)
+      inferno_core (~> 1.2)
       smart_app_launch_test_kit (~> 1.0)
       tls_test_kit (~> 1.0)
 
@@ -141,7 +141,7 @@ GEM
       mutex_m
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    inferno_core (1.1.0)
+    inferno_core (1.2.0)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)

--- a/ipa_test_kit.gemspec
+++ b/ipa_test_kit.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'IPA Inferno tests'
   spec.homepage      = 'https://github.com/inferno-framework/ipa-test-kit'
   spec.license       = 'Apache-2.0'
-  spec.add_runtime_dependency 'inferno_core', '~> 1.0', '>= 1.0.2'
+  spec.add_runtime_dependency 'inferno_core', '~> 1.2'
   spec.add_runtime_dependency 'smart_app_launch_test_kit', '~> 1.0'
   spec.add_runtime_dependency 'tls_test_kit', '~> 1.0'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'

--- a/lib/ipa_test_kit/reference_resolution_test.rb
+++ b/lib/ipa_test_kit/reference_resolution_test.rb
@@ -86,7 +86,7 @@ module IpaTestKit
           found_one_reference = false
 
           resolve_one_reference = resources.any? do |resource|
-            value_found = resolve_path(resource, path)
+            value_found = resolve_path(resource, path).select { |value| value.is_a?(FHIR::Reference) }
             next if value_found.empty?
 
             found_one_reference = true


### PR DESCRIPTION
# Summary

A recent [update to the fhir navigation logic in inferno-core](https://github.com/inferno-framework/inferno-core/pull/770) improved the ability of the resolve_path function. This resulted in some tests failing with purple errors due to unsafe use of the resolve_path function that didn't check the types of the returned values before accessing their properties. This update ensures that all uses of resolve_path are safe.

# Testing Guidance

No explicit test failure was detected, so this is a preemptive fix. Run the test kit using the standard Reference Server preset to ensure no purple errors occur, with a focus on test 2.8.11 in the MedicationRequest group as that is the one that failed in US Core.  You can use SAMPLE_TOKEN as the access token to avoid needing to run the smart tests.